### PR TITLE
Add rbd example to documentation

### DIFF
--- a/doc/examples/rbd-meta.yaml
+++ b/doc/examples/rbd-meta.yaml
@@ -2,7 +2,7 @@ downburst:
   distro: "ubuntu"
   distroversion: "12.04"
   ceph-cluster-name: ceph
-  ceph-cluster-monitors: 127.0.0.1
+  ceph-cluster-monitors: 192.168.1.2:6789,192.168.1.3:6789
   ceph-cluster-pool: rbd
   rbd-disks: 1
   rbd-disks-size: 20G


### PR DESCRIPTION
Add an example yaml configuration to show how to attach rbd volumes
to VMs provisioned with downburst.
