### PR TITLE
support RHEL 6 hypervisors

### DIFF
--- a/downburst/template.xml
+++ b/downburst/template.xml
@@ -3,7 +3,7 @@
   <memory>524288</memory>
   <vcpu>1</vcpu>
   <os>
-    <type arch='x86_64' machine='pc-1.0'>hvm</type>
+    <type arch='x86_64'>hvm</type>
     <boot dev='hd'/>
   </os>
   <features>

--- a/downburst/template.xml
+++ b/downburst/template.xml
@@ -15,7 +15,6 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
     <!-- <disk type='file' device='disk'> -->
     <!--   <driver name='qemu' type='qcow2'/> -->
     <!--   <source file='/var/lib/libvirt/images/NAME.img'/> -->


### PR DESCRIPTION
This pull request removes some hard-coded things in `template.xml` that were incompatible with RHEL 6.

The first commit in this pull request removes the hard-coded machine type from `template.xml`. The second commit removes the hard-coded path to the `qemu-kvm` binary.

The commit logs contain more details. The basic gist is that we can remove these hardcoded elements and libvirt will automatically add them back in with the correct values during the XML import operation.
