### PR TITLE
meta: use canonical KEYURL location

### DIFF
--- a/downburst/meta.py
+++ b/downburst/meta.py
@@ -13,7 +13,7 @@ def get_ssh_pubkey():
         return f.readline().rstrip('\n')
 
 
-KEYURL='http://ceph.com/git/?p=keys.git;a=blob_plain;f=ssh/teuthology-ubuntu.pub;hb=HEAD'
+KEYURL='https://git.ceph.com/?p=keys.git;a=blob_plain;f=ssh/teuthology-ubuntu.pub;hb=HEAD'
 
 def keyfetch():
     print "Fetching default SSH key from "+KEYURL


### PR DESCRIPTION
Follow the HTTP redirects and use the canonical location for the SSH key.

1. `ceph.com/git` -> `git.ceph.com`
2. `http` -> `https`

The purpose of this change is to reduce the strain on the ceph.com web server (and use a secure connection as well).