### PR TITLE
Improve logging, break infinite 'wait for cd tray' loop, add --logfile switch

### DIFF
--- a/downburst/cli.py
+++ b/downburst/cli.py
@@ -19,6 +19,10 @@ def parse_args():
         help='be more verbose',
         )
     parser.add_argument(
+        '-l', '--logfile',
+        help='additional logfile (same as stderr log)',
+        )
+    parser.add_argument(
         '-c', '--connect',
         metavar='URI',
         help='libvirt URI to connect to',
@@ -59,6 +63,10 @@ def main():
     logging.basicConfig(
         level=loglevel,
         )
+
+    if args.logfile:
+        logger = logging.getLogger()
+        logger.addHandler(logging.FileHandler(filename=args.logfile))
 
     try:
         return args.func(args)

--- a/downburst/discover.py
+++ b/downburst/discover.py
@@ -159,7 +159,7 @@ def get(distro, distroversion, arch):
         returndict['hash_function'] = 'sha512'
         return returndict
     else:
-        raise NameError('Image not found on server at ' + URL)
+        raise NameError('Image %s not found on server at %s' % (imagestring, URL))
 
 def add_distro(distro, version, distro_and_versions, codename=None):
     # Create dict entry for Distro, append if exists.

--- a/downburst/exc.py
+++ b/downburst/exc.py
@@ -24,3 +24,8 @@ class ImageHashMismatchError(DownburstError):
     """
     Image SHA-512 did not match
     """
+
+class HostNotProvisioned(DownburstError):
+    """
+    --wait was specified, but the virtual machine never came up
+    """


### PR DESCRIPTION
This will require teuthology to invoke downburst with -l/--logfile