### PR TITLE
requirements-dev.txt: pin libvirt-python to 4.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 lxml >= 2.3.2
 requests
 PyYAML >= 3.10
-libvirt-python
+libvirt-python == 4.0.0


### PR DESCRIPTION
otherwise we will run into
https://bugs.launchpad.net/openstack-requirements/+bug/1753539. we can
bump the required version once libvirt-python fixes this issue.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>