### PR TITLE
iso: add mkisofs in addition to genisoimage

### DIFF
--- a/downburst/discover.py
+++ b/downburst/discover.py
@@ -1,3 +1,4 @@
+import os
 import requests
 import re
 import csv
@@ -5,7 +6,7 @@ import json
 
 from html.parser import HTMLParser
 
-URL="http://download.ceph.com/cloudinit/"
+URL=os.environ.get("DOWNBURST_DISCOVER_URL", "http://download.ceph.com/cloudinit/")
 
 class Parser(HTMLParser):
     def __init__(self):

--- a/downburst/iso.py
+++ b/downburst/iso.py
@@ -1,3 +1,5 @@
+import distro
+import logging
 import os
 import subprocess
 import tempfile
@@ -7,6 +9,7 @@ from lxml import etree
 from . import meta
 from . import template
 
+log = logging.getLogger(__name__)
 
 def generate_meta_iso(
     name,
@@ -24,9 +27,15 @@ def generate_meta_iso(
         meta.write_meta(meta_data=meta_data, fp=meta_f)
         meta.write_user(user_data=user_data, fp=user_f)
 
+        mkisofs = 'mkisofs'
+        log.debug('The host distro id is %s', distro.id())
+        if any(distro.id().startswith(_)
+                    for _ in ('debian', 'ubuntu')):
+            mkisofs = 'genisoimage'
+        log.debug('Using "%s" to create meta iso for "%s"', mkisofs, name)
         subprocess.check_call(
             args=[
-                'genisoimage',
+                mkisofs,
                 '-quiet',
                 '-input-charset', 'utf-8',
                 '-volid', 'cidata',


### PR DESCRIPTION
Since genisoimage is a Debian fork of mkisofs, downburst should
also look for that,  enabling it to work on non-Debian-based
operating systems.

Fixes: https://tracker.ceph.com/issues/7289

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>